### PR TITLE
Review2

### DIFF
--- a/avast-is-trial/avast-is-trial.nuspec
+++ b/avast-is-trial/avast-is-trial.nuspec
@@ -5,7 +5,7 @@
     <version>0.0.1</version>
     <packageSourceUrl>https://github.com/milanoid/chocolatey-avast-packages</packageSourceUrl>
     <owners>Milan Vojnovic</owners>
-    <title>avast-is-trial (Install)</title>
+    <title>Avast Internet Security (Trial)</title>
     <authors>Avast Software</authors>
     <projectUrl>https://www.avast.com/internet-security</projectUrl>
     <iconUrl>https://cdn.rawgit.com/milanoid/chocolatey-avast-packages/master/paid.png</iconUrl>

--- a/avast-is-trial/tools/chocolateybeforemodify.ps1
+++ b/avast-is-trial/tools/chocolateybeforemodify.ps1
@@ -1,9 +1,0 @@
-﻿# This runs in 0.9.10+ before upgrade and uninstall.
-# Use this file to do things like stop services prior to upgrade or uninstall.
-# NOTE: It is an anti-pattern to call chocolateyUninstall.ps1 from here. If you
-#  need to uninstall an MSI prior to upgrade, put the functionality in this
-#  file without calling the uninstall script. Make it idempotent in the
-#  uninstall script so that it doesn't fail when it is already uninstalled.
-# NOTE: For upgrades - like the uninstall script, this script always runs from 
-#  the currently installed version, not from the new upgraded package version.
-

--- a/avast-is-trial/tools/chocolateyinstall.ps1
+++ b/avast-is-trial/tools/chocolateyinstall.ps1
@@ -18,8 +18,6 @@ $packageArgs = @{
   softwareName  = 'avast-is-trial*'
   checksum      = '0cf7b7af3e7632fc1dc49fcb6f6d2f3c'
   checksumType  = 'md5'
-  checksum64    = ''
-  checksumType64= 'md5'
 }
 
 Install-ChocolateyPackage @packageArgs

--- a/avast-is-trial/tools/chocolateyinstall.ps1
+++ b/avast-is-trial/tools/chocolateyinstall.ps1
@@ -5,14 +5,12 @@ $ErrorActionPreference = 'Stop';
 $packageName= 'avast-is-trial'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $url        = 'http://files.avast.com/iavs9x/avast_internet_security_setup_online.exe'
-$url64      = ''
 
 $packageArgs = @{
   packageName   = $packageName
   unzipLocation = $toolsDir
   fileType      = 'EXE'
   url           = $url
-  url64bit      = $url64
 
   silentArgs    = "/silent"
   validExitCodes= @(0, 3010, 1641)

--- a/avast-is-trial/tools/chocolateyuninstall.ps1
+++ b/avast-is-trial/tools/chocolateyuninstall.ps1
@@ -2,9 +2,9 @@
 
 $ErrorActionPreference = 'Stop';
 
-$packageName = 'avast-premier-trial'
-$softwareName = 'avast-premier-trial*'
-$installerType = 'MSI' 
+$packageName = 'avast-is-trial'
+$softwareName = 'avast-is-trial*'
+$installerType = 'EXE' 
 
 $silentArgs = '/qn /norestart'
 $validExitCodes = @(0, 3010, 1605, 1614, 1641)

--- a/avast-premier-trial/avast-premier-trial.nuspec
+++ b/avast-premier-trial/avast-premier-trial.nuspec
@@ -5,7 +5,7 @@
     <version>0.0.1</version>
     <packageSourceUrl>https://github.com/milanoid/chocolatey-avast-packages</packageSourceUrl>
     <owners>Milan Vojnovic</owners>
-    <title>avast-premier-trial (Install)</title>
+    <title>Avast Premier (Trial)</title>
     <authors>Avast Software</authors>
     <projectUrl>https://www.avast.com/en-us/premier</projectUrl>
     <iconUrl>https://cdn.rawgit.com/milanoid/chocolatey-avast-packages/master/paid.png</iconUrl>

--- a/avast-premier-trial/tools/chocolateybeforemodify.ps1
+++ b/avast-premier-trial/tools/chocolateybeforemodify.ps1
@@ -1,9 +1,0 @@
-﻿# This runs in 0.9.10+ before upgrade and uninstall.
-# Use this file to do things like stop services prior to upgrade or uninstall.
-# NOTE: It is an anti-pattern to call chocolateyUninstall.ps1 from here. If you
-#  need to uninstall an MSI prior to upgrade, put the functionality in this
-#  file without calling the uninstall script. Make it idempotent in the
-#  uninstall script so that it doesn't fail when it is already uninstalled.
-# NOTE: For upgrades - like the uninstall script, this script always runs from 
-#  the currently installed version, not from the new upgraded package version.
-

--- a/avast-premier-trial/tools/chocolateyinstall.ps1
+++ b/avast-premier-trial/tools/chocolateyinstall.ps1
@@ -5,15 +5,13 @@ $ErrorActionPreference = 'Stop';
 $packageName= 'avast-premier-trial'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $url        = 'http://files.avast.com/iavs9x/avast_premier_antivirus_setup_online.exe'
-$url64      = ''
 
 $packageArgs = @{
   packageName   = $packageName
   unzipLocation = $toolsDir
   fileType      = 'EXE'
   url           = $url
-  url64bit      = $url64
-
+  
   silentArgs    = "/silent"
   validExitCodes= @(0, 3010, 1641)
 

--- a/avast-premier-trial/tools/chocolateyinstall.ps1
+++ b/avast-premier-trial/tools/chocolateyinstall.ps1
@@ -18,8 +18,6 @@ $packageArgs = @{
   softwareName  = 'avast-premier-trial*'
   checksum      = 'b6e6fad911f99b82bf177954930deabb'
   checksumType  = 'md5'
-  checksum64    = ''
-  checksumType64= 'md5'
 }
 
 Install-ChocolateyPackage @packageArgs

--- a/avast-premier-trial/tools/chocolateyuninstall.ps1
+++ b/avast-premier-trial/tools/chocolateyuninstall.ps1
@@ -4,7 +4,7 @@ $ErrorActionPreference = 'Stop';
 
 $packageName = 'avast-premier-trial'
 $softwareName = 'avast-premier-trial*'
-$installerType = 'MSI' 
+$installerType = 'EXE' 
 
 $silentArgs = '/qn /norestart'
 $validExitCodes = @(0, 3010, 1605, 1614, 1641)

--- a/avast-pro-trial/avast-pro-trial.nuspec
+++ b/avast-pro-trial/avast-pro-trial.nuspec
@@ -5,7 +5,7 @@
     <version>0.0.1</version>
     <packageSourceUrl>https://github.com/milanoid/chocolatey-avast-packages</packageSourceUrl>
     <owners>Milan Vojnovic</owners>
-    <title>avast-pro-trial (Install)</title>
+    <title>Avast Pro Antivirus (Trial)</title>
     <authors>Avast Software</authors>
     <projectUrl>https://www.avast.com/pro-antivirus</projectUrl>
     <iconUrl>https://cdn.rawgit.com/milanoid/chocolatey-avast-packages/master/paid.png</iconUrl>

--- a/avast-pro-trial/tools/chocolateybeforemodify.ps1
+++ b/avast-pro-trial/tools/chocolateybeforemodify.ps1
@@ -1,9 +1,0 @@
-﻿# This runs in 0.9.10+ before upgrade and uninstall.
-# Use this file to do things like stop services prior to upgrade or uninstall.
-# NOTE: It is an anti-pattern to call chocolateyUninstall.ps1 from here. If you
-#  need to uninstall an MSI prior to upgrade, put the functionality in this
-#  file without calling the uninstall script. Make it idempotent in the
-#  uninstall script so that it doesn't fail when it is already uninstalled.
-# NOTE: For upgrades - like the uninstall script, this script always runs from 
-#  the currently installed version, not from the new upgraded package version.
-

--- a/avast-pro-trial/tools/chocolateyinstall.ps1
+++ b/avast-pro-trial/tools/chocolateyinstall.ps1
@@ -18,8 +18,6 @@ $packageArgs = @{
   softwareName  = 'avast-pro-trial*'
   checksum      = '4664e40cd0f534422c96d650e738c469'
   checksumType  = 'md5'
-  checksum64    = ''
-  checksumType64= 'md5'
 }
 
 Install-ChocolateyPackage @packageArgs

--- a/avast-pro-trial/tools/chocolateyinstall.ps1
+++ b/avast-pro-trial/tools/chocolateyinstall.ps1
@@ -5,15 +5,13 @@ $ErrorActionPreference = 'Stop';
 $packageName= 'avast-pro-trial'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $url        = 'http://files.avast.com/iavs9x/avast_pro_antivirus_setup_online.exe'
-$url64      = ''
 
 $packageArgs = @{
   packageName   = $packageName
   unzipLocation = $toolsDir
   fileType      = 'EXE'
   url           = $url
-  url64bit      = $url64
-
+  
   silentArgs    = "/silent"
   validExitCodes= @(0, 3010, 1641)
 

--- a/avast-pro-trial/tools/chocolateyuninstall.ps1
+++ b/avast-pro-trial/tools/chocolateyuninstall.ps1
@@ -2,9 +2,9 @@
 
 $ErrorActionPreference = 'Stop';
 
-$packageName = 'avast-premier-trial'
-$softwareName = 'avast-premier-trial*'
-$installerType = 'MSI' 
+$packageName = 'avast-pro-trial'
+$softwareName = 'avast-pro-trial*'
+$installerType = 'EXE' 
 
 $silentArgs = '/qn /norestart'
 $validExitCodes = @(0, 3010, 1605, 1614, 1641)


### PR DESCRIPTION
Known issue - uninstall script uninstalls Avast (non-silently) but then the install of the same Avast package fails probably due to incorrect uninstall.